### PR TITLE
Rails 5 compatibility

### DIFF
--- a/gem_version.rb
+++ b/gem_version.rb
@@ -1,3 +1,3 @@
 module TheRoleApi
-  VERSION = "3.0.3"
+  VERSION = "3.0.4"
 end

--- a/lib/the_role_api.rb
+++ b/lib/the_role_api.rb
@@ -37,8 +37,8 @@ module TheRole
       config.autoload_paths << "#{ config.root }/app/controllers/concerns/**"
     end
 
-    if Rails::VERSION::MAJOR == 5
-      raise Exception.new("TheRole 3. Version for Rails 5 not tested yet")
+    if Rails::VERSION::MAJOR > 5
+      raise Exception.new("TheRole 3. Version for Rails > 5 not tested yet")
     end
 
     initializer "the_role_precompile_hook", group: :all do |app|

--- a/the_role_api.gemspec
+++ b/the_role_api.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'multi_json'
   s.add_dependency 'the_string_to_slug', '~> 1.2'
-  s.add_runtime_dependency 'rails', ['>= 3.2', '< 5']
+  s.add_runtime_dependency 'rails', ['>= 3.2', '<= 5.0']
 end


### PR DESCRIPTION
It seems to be everything works fine with rails 5. See: https://github.com/the-teacher/the_role/issues/77

One minor thing: The gem https://github.com/TheProfitCMS/the_string_to_slug throws a 

```
DEPRECATION WARNING: Passing the separator argument as a positional parameter is deprecated and will soon be removed. Use `separator: '-'` instead.
```

in the `parameters` call:

https://github.com/TheProfitCMS/the_string_to_slug/blob/master/lib/the_string_to_slug.rb#L29

Not sure how this gem is related to you guys because https://github.com/the-teacher/the_string_to_slug seems to be https://github.com/TheProfitCMS/the_string_to_slug now? Should I create a PR as well?

Many thanks!